### PR TITLE
i-PI driver implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,16 +11,21 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 AtomsBase = "0.3"
 AtomsCalculators = "0.1.2"
 Folds = "0.2.10"
-Unitful = "1"
-julia = "1.9, 1.10"
+LinearAlgebra = "1.9"
+Printf = "1.9"
+Sockets = "1.9"
 StaticArrays = "1" 
-LinearAlgebra = "1.9, 1.10"
-Printf = "1.9, 1.10"
+Unitful = "1"
+UnitfulAtomic = "1"
+julia = "1.9"
+
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "i-PI Driver" => "ipi.md"
     ],
 )
 

--- a/docs/src/ipi.md
+++ b/docs/src/ipi.md
@@ -45,7 +45,7 @@ i-PI protocol will always calculate energy, forces and virial, thus your calcula
 calculation.
 
 For calculators that do not support virial calculations `AtomsUtilityCalcualtors.Calculators` implements
-`ZeroVirialCalculator` that adds virial caluculation support for your calculator. Note that this is in correct. So use it on your own risk!
+`ZeroVirialCalculator` that adds virial caluculation support for your calculator. Note that this is in correct. So use it at your own risk!
 
 One good use case for this is constant volume simulations, where
 virial is ignored, but i-PI protocol still calculates it.

--- a/docs/src/ipi.md
+++ b/docs/src/ipi.md
@@ -1,0 +1,93 @@
+# i-PI driver interface
+
+[i-PI](https://github.com/i-pi/i-pi) is a universal force engine that defines
+protocol for energy, force and virial calculation.
+
+AtomsCalculatorUtilities has a submodule IPI that implement i-PI interface for
+AtomsCalculators compatable caluculators.
+
+## i-PI basic consepts
+
+The interface is based on server and calculator, called driver, interaction.
+Server is setup by either network mode or a unixpipe mode.
+
+Following starts [ASE](https://wiki.fysik.dtu.dk/ase/index.html) SocketIOCalculator that is a i-PI server implementation, using default port 31415
+
+```python
+from ase.calculators.socketio import SocketIOCalculator
+calc = SocketIOCalculator(log="test.log")
+```
+
+You then need to connect a calculator (driver) to it. To do this you need to tell the calculator what kind of system (atom symbols) are used in the calculation, as i-PI protocol does not transfer atomic symbols.
+
+After you have connected the calculator (driver), you can use the ASE calculator to perform calculations.
+
+## Use Julia driver
+
+To start Julia driver you need to first create a AtomsCalculators compatable calculator and an AtomsBase system structure that initializes atomic symbols.
+
+Then you connect them to a driver by calling `run_driver`
+
+```julia
+using AtomsCalculatorsUtilities.IPI
+
+mycalc = # Create your calculator
+sys_init = # Create initial system
+
+run_driver("127.0.0.1", mycalc, sys-init)
+```
+
+After this the server works as a calculator, using your Julia calculator as a backend.
+
+## Things to note
+
+i-PI protocol will always calculate energy, forces and virial, thus your calculator need to support virial
+calculation.
+
+For calculators that do not support virial calculations `AtomsUtilityCalcualtors.Calculators` implements
+`ZeroVirialCalculator` that adds virial caluculation support for your calculator. Note that this is in correct. So use it on your own risk!
+
+One good use case for this is constant volume simulations, where
+virial is ignored, but i-PI protocol still calculates it.
+
+## Working example
+
+Start SocketIOCalculator in python
+
+```python
+from ase import Atoms
+from ase.calculators.socketio import SocketIOCalculator
+
+h2 = Atoms('H2', positions=[[0, 0, 0], [0, 0, 0.7]])
+
+calc = SocketIOCalculator(log="test.log")
+
+h2.calc = calc
+h2.get_forces()  # this will stall untill you connect a driver
+```
+
+In Julia you then create a driver
+
+```julia
+using AtomsCalculatorsUtilities.Calculators
+using AtomsCalculatorsUtilities.IPI
+using ORCAcalculator
+using Unitful
+using AtomsBase
+
+ox = ORCAexecutable()
+om = ORCAmethod("blyp def2-TZVPP TIGHTSCF defgrid3")
+
+hydrogen = isolated_system([
+    :H => [0, 0, 0.]u"Å",
+    :H => [0, 0, 1.]u"Å"
+])
+
+orca = ORCAcalculatorbundle(ox, om)
+
+calc = ZeroVirialCalculator(orca)
+
+run_driver("127.0.0.1", calc, hydrogen)
+```
+
+Now you can perform calculations in ASE.

--- a/src/AtomsCalculatorsUtilities.jl
+++ b/src/AtomsCalculatorsUtilities.jl
@@ -13,6 +13,10 @@ module Calculators
     include("calculators/zero_virial_calculator.jl")
 end # module Calculators
 
+module IPI
+    include("ipi/ipi_interface.jl")
+end
+
 module Testing 
     include("testing/fdtests.jl")
 end 

--- a/src/calculators/zero_virial_calculator.jl
+++ b/src/calculators/zero_virial_calculator.jl
@@ -10,6 +10,8 @@ This calculator helps to add virial calculation to a calculator
 that does not have it supported. This allows to embed the calculator
 to calculations that need some value for virial returned.
 
+Note that forcing zero virial is incorrect. Use at your own risk.
+
 # Fields
 - calculator::T    :  calculator used for potential energy and forces
 - virial_unit::VU  :  unit given to zero virial - default eV

--- a/src/calculators/zero_virial_calculator.jl
+++ b/src/calculators/zero_virial_calculator.jl
@@ -27,6 +27,7 @@ mutable struct ZeroVirialCalculator{T,VU}
     calculator::T
     virial_unit::VU
     function ZeroVirialCalculator(calc; virial_unit::Unitful.EnergyUnits=u"eV")
+        @warn "Setting virial to zeros leads to errors! Use on your own risk."
         new{typeof(calc), typeof(virial_unit)}(calc, virial_unit)
     end
 end

--- a/src/ipi/ipi_interface.jl
+++ b/src/ipi/ipi_interface.jl
@@ -82,7 +82,7 @@ function sendforce(comm, e::Number, forces::AbstractVector, virial::AbstractMatr
 end
 
 """
-    run_driver(address, potential, init_structure; port=31415, unixsocket=false )
+    run_driver(address, calculator, init_structure; port=31415, unixsocket=false )
 
 Connect I-PI driver to server at given `address`. Use kword `port` (default 31415) to
 specify port. If kword `unixsocket` is true, `address` is understood to be the name of the socket
@@ -91,8 +91,11 @@ and `port` option is ignored.
 You need to give initial structure as I-PI protocol does not transfer atom symbols.
 This means that, if you want to change the number of atoms or their symbols, you need
 to lauch a new driver.
+
+Calculator events are logged at info level by default. If you do not want them to be logged,
+change logging status for IPI module.
 """
-function run_driver(address, potential, init_structure; port=31415, unixsocket=false )
+function run_driver(address, calc, init_structure; port=31415, unixsocket=false )
     if unixsocket
         comm = connect("/tmp/ipi_"*address)
     else
@@ -132,7 +135,7 @@ function run_driver(address, potential, init_structure; port=31415, unixsocket=f
             cell = pos[:cell]
             @assert length(symbols) == length(positions) "received amount of position data does no match the atomic symbol data"
             system = FastSystem(cell, pbc, positions, symbols, anumbers, masses)
-            data = AtomsCalculators.energy_forces_virial(system, potential)
+            data = AtomsCalculators.energy_forces_virial(system, calc)
             has_data = true
         elseif header == "GETFORCE"
             sendforce(comm, data[:energy], data[:forces], data[:virial])

--- a/src/ipi/ipi_interface.jl
+++ b/src/ipi/ipi_interface.jl
@@ -1,0 +1,150 @@
+# This is AtomsCalculators implementation for i-PI protocol.
+# For reference see https://github.com/i-pi/i-pi/blob/master/drivers/py/driver.py
+
+using AtomsBase
+using AtomsCalculators
+using Sockets
+using StaticArrays
+using Unitful
+using UnitfulAtomic
+
+export run_driver
+
+const hdrlen = 12
+const pos_type = typeof(SVector(1., 1., 1.)u"bohr") #should be bohr
+
+function sendmsg(comm, message; nbytes=hdrlen)
+    @info "Sending message" message
+    if length(message) == nbytes
+        final_message = message
+    elseif length(message) < nbytes
+        l = nbytes - length(message)
+        final_message = message * repeat(' ', l)
+    else
+        error("Message is too long")
+    end
+    write(comm, final_message)
+end
+
+
+function recvmsg(comm, nbytes=hdrlen)
+    raw_message = read(comm, nbytes)
+    if length(raw_message) == 0
+        @info "Server was probably closed and did not send EXIT"
+        return "EXIT"
+    end
+    @assert length(raw_message) == nbytes "recieved message did not have correct lenght"
+    message = Char.(raw_message) |> String |> strip
+    @info "Recieved message" message
+    return message
+end
+
+function recvinit(comm)
+    @info "Recieving INIT"
+    bead_index = read(comm, Int32)
+    nbytes = read(comm, Int32)
+    raw_data = read(comm, nbytes)
+    message = Char.(raw_data) |> String |> strip
+    return (;
+        :bead_index => bead_index,
+        :message => message
+    )
+end
+
+
+function recvposdata(comm)
+    raw_cell = read(comm, 9*8)
+    raw_icell = read(comm, 9*8) # drop this (inverce cell)
+    natoms = read(comm, Int32)
+    raw_pos = read(comm, 8*3*natoms)
+    data_cell = reinterpret(pos_type, raw_cell)
+    data_pos = reinterpret(pos_type, raw_pos)
+    @info "Position data recieved"
+    return (;
+        :cell => Vector(data_cell),
+        :positions => Vector(data_pos)  # clean type a little bit
+    )
+end
+
+
+function sendforce(comm, e::Number, forces::AbstractVector, virial::AbstractMatrix)
+    etype = (eltype ∘ eltype)(forces)
+    f_tmp = reinterpret(reshape, etype, forces)
+    sendmsg(comm, "FORCEREADY")
+    write(comm, ustrip(u"hartree", e) )
+    write(comm, Int32( length(forces) ) )
+    write(comm, ustrip.(u"hartree/bohr", f_tmp) )
+    write(comm, ustrip.(u"hartree", virial) )
+
+    # Send single byte at end to make sure we are alive
+    write(comm, one(Int32) )
+    write(comm, zero(UInt8) )
+end
+
+"""
+    run_driver(address, potential, init_structure; port=31415, unixsocket=false )
+
+Connect I-PI driver to server at given `address`. Use kword `port` (default 31415) to
+specify port. If kword `unixsocket` is true, `address` is understood to be the name of the socket
+and `port` option is ignored.
+
+You need to give initial structure as I-PI protocol does not transfer atom symbols.
+This means that, if you want to change the number of atoms or their symbols, you need
+to lauch a new driver.
+"""
+function run_driver(address, potential, init_structure; port=31415, unixsocket=false )
+    if unixsocket
+        comm = connect("/tmp/ipi_"*address)
+    else
+        comm = connect(address, port)
+    end
+    has_init = false
+    has_data = false
+    data = nothing
+
+    masses = atomic_mass(init_structure)
+    symbols = atomic_symbol(init_structure)
+    anumbers = atomic_number(init_structure)
+    positions = position(init_structure)
+    cell = bounding_box(init_structure)
+    pbc =  boundary_conditions(init_structure)
+
+
+    while true
+        header = recvmsg(comm)
+
+        if header == "STATUS"
+            if !has_init
+                sendmsg(comm, "NEEDINIT")
+            elseif has_data
+                sendmsg(comm, "HAVEDATA")
+            else
+                sendmsg(comm, "READY")
+            end
+        elseif header == "INIT"
+            init = recvinit(comm)
+            # we don't init anything for now
+            has_init = true
+            has_data = false
+        elseif header == "POSDATA"
+            pos = recvposdata(comm)
+            positions = pos[:positions]
+            cell = pos[:cell]
+            @assert length(symbols) == length(positions) "received amount of position data does no match the atomic symbol data"
+            system = FastSystem(cell, pbc, positions, symbols, anumbers, masses)
+            data = AtomsCalculators.energy_forces_virial(system, potential)
+            has_data = true
+        elseif header == "GETFORCE"
+            sendforce(comm, data[:energy], data[:forces], data[:virial])
+            has_data = false
+        elseif header == "EXIT"
+            @info "Exiting calculator" 
+            close(comm)
+            break
+        else
+            close(comm)
+            error("Message not recognised")
+        end
+        
+    end
+end


### PR DESCRIPTION
This adds i-PI driver that allows to use AtomsCalculators with ASE and other programs that support i-PI protocol.

Testing the driver routine is a bit tricky, so I'll skip the test now and add it later when we finnish ACU. 