### PR TITLE
Fix IPI driver

### DIFF
--- a/src/ipi/ipi_interface.jl
+++ b/src/ipi/ipi_interface.jl
@@ -101,7 +101,7 @@ function run_driver(address, calc, init_structure; port=31415, unixsocket=false 
     else
         comm = connect(address, port)
     end
-    has_init = false
+    has_init = true  # we have init structure as an input
     has_data = false
     data = nothing
 


### PR DESCRIPTION
Small fix for i-PI driver.

By default the driver needed an init, while when creating the driver you have to give initialization structure. This PR changes the status, so that the driver now does not need an init anymore.

This will allow the driver to work with larger selection of i-PI servers.