### PR TITLE
fix AtomsBase v0.4 support

### DIFF
--- a/src/sitepotentials/sitepotentials.jl
+++ b/src/sitepotentials/sitepotentials.jl
@@ -1,8 +1,15 @@
 
 module SitePotentials 
 
-using AtomsBase, AtomsCalculators, ChunkSplitters, Folds, NeighbourLists, 
-      Unitful, Bumper, StrideArrays 
+using AtomsBase
+using AtomsBase: AbstractSystem
+using AtomsCalculators
+using ChunkSplitters
+using Folds
+using NeighbourLists
+using Unitful
+using Bumper
+using StrideArrays 
 
 using StaticArrays: SVector, SMatrix 
 


### PR DESCRIPTION
Due to [NeighbourLists.jl](https://github.com/JuliaMolSim/NeighbourLists.jl) and limited to AtomsBase v0.3, #26 passed the test and allowed a bug to pass in. This will fix that.